### PR TITLE
Fix for Rollup packaging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { configureClips,runClipsPipeline } from "./src/clips.mjs";
+import { configureClips,runClipsPipeline } from "./dist/node/clips.js";
 import { read_csv } from "./src/io.mjs";
 
 await configureClips()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "node index.js"
+    "dev": "node index.js",
+    "build": "./node_modules/.bin/rollup -c"
   },
   "devDependencies": {
     "@rollup-extras/plugin-copy": "^1.11.0",

--- a/src/clips.mjs
+++ b/src/clips.mjs
@@ -1,6 +1,6 @@
 import {embedData,init as pipelineInit} from './embed.mjs'
 import { cacheCrosswalk, crosswalk } from './crosswalk.mjs';
-import { device,getOnnxRuntime } from './env.js';
+import { device, ort } from './env.js';
 
 let pipelineData = {
     "0.0.2": {
@@ -38,7 +38,7 @@ export async function runClipsPipeline(data){
     // Step 2. Feature Extraction:
     let embeded_ps = await embedData(data)
 
-    let ort = await getOnnxRuntime();
+    // const ort = await getOnnxRuntime()
     const embedding_tensor = new ort.Tensor('float32',embeded_ps.data, embeded_ps.dims);
 
     // Step 3. Handle the crosswalking (naics2022 has 689 5-digit codes.)

--- a/src/embed.mjs
+++ b/src/embed.mjs
@@ -1,11 +1,9 @@
-import { pipeline } from '@huggingface/transformers';
-
-let transformers;
 let embedder;
 let embeddingConfig;
 
 export async function init(pipelineData){
     console.log("... starting initialization embed.mjs")
+    const { pipeline } = await import("@huggingface/transformers")
     embedder = await pipeline("feature-extraction",pipelineData.model,pipelineData.config)
     embeddingConfig = pipelineData.embeddingConfig;
     console.log("... initialization complete embed.mjs")

--- a/src/env.js
+++ b/src/env.js
@@ -7,23 +7,8 @@ const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator
 const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
 const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
 
-export const device = IS_NODE_ENV?"cpu":(IS_WEBGPU_AVAILABLE?"webgpu":"wasm");
-export async function getOnnxRuntime(){
-    let ort;
-    if (IS_NODE_ENV) {
-        ort = await import('onnxruntime-node')
-    } else {
-        ort =  await import('onnxruntime-web')
-    }
+export const device = IS_NODE_ENV ? "cpu":(IS_WEBGPU_AVAILABLE?"webgpu":"wasm");
 
-    return ort;
-}
+export const ort = IS_NODE_ENV ? await import('onnxruntime-node') : await import('onnxruntime-web')
 
-/*
-ort.env.wasm.wasmPaths = {
-    'ort-wasm-simd-threaded.jsep.wasm': './dist/browser/ort-wasm-simd-threaded.jsep.wasm',
-    'ort-wasm-simd.wasm': './dist/browser/ort-wasm-simd.wasm',
-    'ort-wasm-threaded.wasm': './dist/browser/ort-wasm-threaded.wasm',
-}
-console.log("set wasm path ====>",ort.env.wasm.wasmPaths)
-*/
+ort.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/'


### PR DESCRIPTION
This PR primarily does the following:
1. Transformers.js is now imported dynamically inside `configureClips`.
2. ONNX is imported at the top level of the `env` module, instead of via a function invocation.

Both of these together help to avoid clashes with the ONNX dependencies that Transformers.js and `runClipsPipeline` each uses, which was what caused the error. This is specifically due to the way Transformers.js imports ONNX (see https://huggingface.co/docs/transformers.js/en/api/backends/onnx#module_backends/onnx ).

The code can now be packaged using rollup. Tested both browser and node distributables, work well 👍️.